### PR TITLE
Remove bold formatting from Scribble title

### DIFF
--- a/dos/dos.scrbl
+++ b/dos/dos.scrbl
@@ -3,7 +3,7 @@
                      racket/contract/base
                      racket/bool))
 
-@title{@bold{DOS}: Delimited-continuation-based Operating-system Simulator}
+@title{DOS: Delimited-continuation-based Operating-system Simulator}
 @author{Jay McCarthy}
 
 This library provides a set of operating-system-like kernels, where


### PR DESCRIPTION
For consistency with other docs.